### PR TITLE
Proctoring fader 2020 08 13

### DIFF
--- a/entry.php
+++ b/entry.php
@@ -29,7 +29,6 @@ require_login();
 global $DB;
 
 $accesscode = required_param('accesscode', PARAM_RAW);
-$client_origin = optional_param('examus-client-origin', null, PARAM_URL);
 
 $entry = $DB->get_record('availability_examus', ['accesscode' => $accesscode]);
 
@@ -40,7 +39,6 @@ if ($entry) {
     $cmid = $entry->cmid;
 
     $_SESSION['examus'] = $accesscode;
-    $_SESSION['examus_client_origin'] = $client_origin;
 
     list($course, $cm) = get_course_and_cm_from_cmid($cmid);
 

--- a/lib.php
+++ b/lib.php
@@ -51,9 +51,6 @@ function availability_examus_before_standard_html_head(){
         return;
     }
 
-
-    $origin = isset($_SESSION['examus_client_origin']) ? $_SESSION['examus_client_origin'] : '';
-
     ob_start();
     include(dirname(__FILE__).'/proctoring_fader.php');
     $output = ob_get_clean();

--- a/proctoring_fader.php
+++ b/proctoring_fader.php
@@ -1,20 +1,63 @@
 <script type="text/javascript">
-    (function(){
-      var str_awaiting_proctoring = <?= json_encode(get_string('fader_awaiting_proctoring', 'availability_examus')) ?>;
-      var str_instructions = <?= json_encode(get_string('fader_instructions', 'availability_examus')) ?>;
-      //msg queue, inited ASAP, so we don't miss anything
-      var examus_q = [];
-      var expected_origin = <?= json_encode($origin) ?>;
+/**
+ * Hide quiz questions unless it's being proctored.
+ *
+ * Firstly, hide questions with an overlay element.
+ * Then send request to the parent window,
+ * and wait for the answer.
+ *
+ * When got a proper answer, then reveal the quiz content.
+ *
+ * We expect Examus to work only on fresh browsers,
+ * so we use modern javascript here, without any regret or fear.
+ * Even if some old browser breaks parsing or executing this,
+ * no other scripts will be affected.
+ */
+(function(){
 
-      console.log(expected_origin);
+var str_awaiting_proctoring = <?= json_encode(get_string('fader_awaiting_proctoring', 'availability_examus')) ?>;
+var str_instructions = <?= json_encode(get_string('fader_instructions', 'availability_examus')) ?>;
+//msg queue, inited ASAP, so we don't miss anything
+var examus_q = [];
+
+/*
+ * Origin of sender, that is of the proctoring application.
+ * We cache it in `sessionStorage`, so that if it occasionally disappears from the url,
+ * then we've got a previously known value.
+ */
+
+let {sessionStorage, location} = window
+
+let TAG = 'proctoring fader'
+
+let key = 'examus-client-origin'
+let from_storage = () => sessionStorage.get(key)
+let to_storage = x => sessionStorage.set(key, x)
+let from_url = () =>
+  new URL(location.href)
+  .searchParams
+  .get('examus-client-origin')
+
+/* We prefer the value stored in sessionStorage,
+ * to resist against spoofing of the query param. */
+
+/* Read value from url only when there is no value stored yet. */
+if (!from_storage()) to_storage(from_url())
+
+let expected_origin = from_storage()
+
+if (!expected_orgin) {
+  console.error(TAG, 'missing `expected_origin`')
+}
 
       window.addEventListener("message", function(e){
-        console.log(e.origin, expected_origin);
-        if(e.origin == expected_origin){
-          examus_q.push(e.data); console.log(e.data);
+        console.debug(TAG, 'got some message', e.origin, expected_origin);
+        if(e.origin === expected_origin){
+          examus_q.push(e.data); console.debug(TAG, 'got proved message', e.data);
         }
         check();
       });
+
       var examusFader;
       window.addEventListener("DOMContentLoaded", function(){
         console.log("loaded");

--- a/proctoring_fader.php
+++ b/proctoring_fader.php
@@ -75,31 +75,31 @@ let proved = new Promise(resolve => {
 /**
  * Prepare the element to cover quiz contents.
  */
-let examus_fader = () => {
-  let x = document.createElement("div")
+const examus_fader = () => {
+  const x = document.createElement("div");
 
-  x.innerHTML = fader_html
+  x.innerHTML = fader_html;
 
-  let style = {
+  const style = {
     position: 'fixed',
     zIndex: 1000,
-    font-size: 2em,
-    width: 100%,
-    height: 100%,
-    background: #fff,
+    fontSize: '2em',
+    width: '100%',
+    height: '100%',
+    background: '#fff',
     top: 0,
     left: 0,
-    text-align: center,
-    display: flex,
-    justify-content: center,
-    align-content: center,
-    flex-direction: column
-  }
+    textAlign: 'center',
+    display: 'flex',
+    justifyContent: 'center',
+    alignContent: 'center',
+    flexDirection: 'column',
+  };
 
-  Object.assign(x.style, style)
+  Object.assign(x.style, style);
 
-  return x
-}
+  return x;
+};
 
 window.addEventListener("DOMContentLoaded", function() {
   let el = examus_fader()

--- a/proctoring_fader.php
+++ b/proctoring_fader.php
@@ -17,8 +17,15 @@
 
 var str_awaiting_proctoring = <?= json_encode(get_string('fader_awaiting_proctoring', 'availability_examus')) ?>;
 var str_instructions = <?= json_encode(get_string('fader_instructions', 'availability_examus')) ?>;
-//msg queue, inited ASAP, so we don't miss anything
-var examus_q = [];
+let fader_html = str_awaiting_proctoring + str_instructions
+
+let {sessionStorage, location} = window
+
+let TAG = 'proctoring fader'
+
+let key = 'examus-client-origin'
+
+let expected_data = 'proctoringReady_n6EY'
 
 /*
  * Origin of sender, that is of the proctoring application.
@@ -26,11 +33,6 @@ var examus_q = [];
  * then we've got a previously known value.
  */
 
-let {sessionStorage, location} = window
-
-let TAG = 'proctoring fader'
-
-let key = 'examus-client-origin'
 let from_storage = () => sessionStorage.get(key)
 let to_storage = x => sessionStorage.set(key, x)
 let from_url = () =>
@@ -46,37 +48,69 @@ if (!from_storage()) to_storage(from_url())
 
 let expected_origin = from_storage()
 
-if (!expected_orgin) {
+if (!expected_origin) {
   console.error(TAG, 'missing `expected_origin`')
 }
 
-      window.addEventListener("message", function(e){
-        console.debug(TAG, 'got some message', e.origin, expected_origin);
-        if(e.origin === expected_origin){
-          examus_q.push(e.data); console.debug(TAG, 'got proved message', e.data);
-        }
-        check();
-      });
+/**
+ * Promise, which resolves when got a message proving the page is being proctored.
+ * TODO postpone the effect
+ */
+let proved = new Promise(resolve => {
+  let f = e => {
+    console.debug(TAG, 'got some message', e.origin, expected_origin)
 
-      var examusFader;
-      window.addEventListener("DOMContentLoaded", function(){
-        console.log("loaded");
-        examusFader = document.createElement("DIV");
-        examusFader.innerHTML = str_awaiting_proctoring + str_instructions;
-        examusFader.style="position: fixed; z-index: 1000; font-size: 2em; width: 100%; height: 100%; background: #fff; top: 0; left: 0;text-align: center;display: flex;justify-content: center;align-content: center;flex-direction: column;";
-        document.body.appendChild(examusFader);
-        if(!check()){
-          if(window.parent && window.parent != window){
-            window.parent.postMessage('proctoringRequest', expected_origin);
-          }
-        }
-      });
-      function check(){
-        if(examus_q && examus_q[0]){
-          unlock();
-          return true;
-        }
-      }
-      function unlock(){ if(examusFader) examusFader.remove(); examusFader = null; }
-    })();
+    if (e.origin === expected_origin &&
+        e.data === expected_data
+    ) {
+      resolve()
+      console.debug(TAG, 'got proved message', e.data)
+      window.removeEventListener('message', f)
+    }
+  }
+
+  window.addEventListener("message", f)
+})
+
+/**
+ * Prepare the element to cover quiz contents.
+ */
+let examus_fader = () => {
+  let x = document.createElement("div")
+
+  x.innerHTML = fader_html
+
+  let style = {
+    position: 'fixed',
+    zIndex: 1000,
+    font-size: 2em,
+    width: 100%,
+    height: 100%,
+    background: #fff,
+    top: 0,
+    left: 0,
+    text-align: center,
+    display: flex,
+    justify-content: center,
+    align-content: center,
+    flex-direction: column
+  }
+
+  Object.assign(x.style, style)
+
+  return x
+}
+
+  window.addEventListener("DOMContentLoaded", function() {
+    let el = examus_fader()
+
+    document.body.appendChild(el)
+
+    proved.then(() => el.remove())
+
+    /* Most of the time this action is meaningless,
+     * at the same time it's always harmless. */
+    window.parent.postMessage('proctoringRequest', expected_origin);
+  });
+})();
 </script>

--- a/proctoring_fader.php
+++ b/proctoring_fader.php
@@ -22,35 +22,34 @@ const faderHTML = strAwaitingProctoring + strInstructions;
 const {sessionStorage, location} = window;
 
 const TAG = 'proctoring fader';
-
-const expectedData = (x) => 'proctoringReady_n6EY';
+const expectedData = 'proctoringReady_n6EY';
 
 /**
  * Promise, which resolves when got a message proving the page is being proctored.
  */
 const waitForProof = () => new Promise(resolve => {
-  const f = e => {
+  const messageHandler = e => {
     console.debug(TAG, 'got some message', e.data);
 
-    if (expectedData(e.data)) {
+    if (expectedData === e.data) {
       resolve();
       console.debug(TAG, 'got proving message', e.data);
-      window.removeEventListener('message', f);
+      window.removeEventListener('message', messageHandler);
     }
   }
 
-  window.addEventListener("message", f);
+  window.addEventListener("message", messageHandler);
 });
 
 /**
  * Prepare the element to cover quiz contents.
  */
 const createFader = () => {
-  const x = document.createElement("div");
+  const fader = document.createElement("div");
 
-  x.innerHTML = faderHTML;
+  fader.innerHTML = faderHTML;
 
-  const style = {
+  Object.assign(fader.style, {
     position: 'fixed',
     zIndex: 1000,
     fontSize: '2em',
@@ -64,11 +63,9 @@ const createFader = () => {
     justifyContent: 'center',
     alignContent: 'center',
     flexDirection: 'column',
-  };
+  });
 
-  Object.assign(x.style, style);
-
-  return x;
+  return fader;
 };
 
 /**

--- a/proctoring_fader.php
+++ b/proctoring_fader.php
@@ -101,16 +101,17 @@ let examus_fader = () => {
   return x
 }
 
-  window.addEventListener("DOMContentLoaded", function() {
-    let el = examus_fader()
+window.addEventListener("DOMContentLoaded", function() {
+  let el = examus_fader()
 
-    document.body.appendChild(el)
+  document.body.appendChild(el)
 
-    proved.then(() => el.remove())
+  proved.then(() => el.remove())
 
-    /* Most of the time this action is meaningless,
-     * at the same time it's always harmless. */
-    window.parent.postMessage('proctoringRequest', expected_origin);
-  });
+  /* Most of the time this action is meaningless,
+   * at the same time it's always harmless. */
+  window.parent.postMessage('proctoringRequest', expected_origin);
+});
+
 })();
 </script>

--- a/proctoring_fader.php
+++ b/proctoring_fader.php
@@ -106,9 +106,10 @@ const createFader = () => {
 };
 
 window.addEventListener("DOMContentLoaded", () => {
-  document.body.appendChild(createFader());
+  const fader = createFader();
+  document.body.appendChild(fader);
 
-  proved.then(() => el.remove());
+  proved.then(() => fader.remove());
 
   /* Most of the time this action is meaningless,
    * at the same time it's always harmless. */

--- a/proctoring_fader.php
+++ b/proctoring_fader.php
@@ -15,17 +15,18 @@
  */
 (function(){
 
-var str_awaiting_proctoring = <?= json_encode(get_string('fader_awaiting_proctoring', 'availability_examus')) ?>;
-var str_instructions = <?= json_encode(get_string('fader_instructions', 'availability_examus')) ?>;
-let fader_html = str_awaiting_proctoring + str_instructions
+const strAwaitingProctoring = <?= json_encode(get_string('fader_awaiting_proctoring', 'availability_examus')) ?>;
+const strInstructions = <?= json_encode(get_string('fader_instructions', 'availability_examus')) ?>;
+const faderHTML = strAwaitingProctoring + strInstructions;
 
-let {sessionStorage, location} = window
+const {sessionStorage, location} = window;
 
-let TAG = 'proctoring fader'
+const TAG = 'proctoring fader';
 
-let key = 'examus-client-origin'
+const storageKey = 'examus-client-origin';
+const urlParam   = 'examus-client-origin';
 
-let expected_data = 'proctoringReady_n6EY'
+const expectedData = 'proctoringReady_n6EY';
 
 /*
  * Origin of sender, that is of the proctoring application.
@@ -33,52 +34,55 @@ let expected_data = 'proctoringReady_n6EY'
  * then we've got a previously known value.
  */
 
-let from_storage = () => sessionStorage.get(key)
-let to_storage = x => sessionStorage.set(key, x)
-let from_url = () =>
+const fromStorage = ()  => sessionStorage.get(storageKey);
+const toStorage   = (x) => sessionStorage.set(storageKey, x);
+
+const fromUrl = () =>
   new URL(location.href)
   .searchParams
-  .get('examus-client-origin')
+  .get(urlParam);
 
 /* We prefer the value stored in sessionStorage,
  * to resist against spoofing of the query param. */
 
 /* Read value from url only when there is no value stored yet. */
-if (!from_storage()) to_storage(from_url())
+if (!fromStorage()){
+  toStorage(fromUrl());
+}
 
-let expected_origin = from_storage()
+const expectedOrigin = fromStorage();
 
-if (!expected_origin) {
-  console.error(TAG, 'missing `expected_origin`')
+if (!expectedOrigin) {
+  console.error(TAG, 'missing `expectedOrigin`');
 }
 
 /**
  * Promise, which resolves when got a message proving the page is being proctored.
  * TODO postpone the effect
  */
-let proved = new Promise(resolve => {
-  let f = e => {
-    console.debug(TAG, 'got some message', e.origin, expected_origin)
+const proved = new Promise(resolve => {
+  const f = e => {
+    console.debug(TAG, 'got some message', e.origin, expectedOrigin);
 
-    if (e.origin === expected_origin &&
-        e.data === expected_data
+    if (e.origin === expectedOrigin &&
+        e.data === expectedData
     ) {
-      resolve()
-      console.debug(TAG, 'got proved message', e.data)
-      window.removeEventListener('message', f)
+      resolve();
+      console.debug(TAG, 'got proved message', e.data);
+      window.removeEventListener('message', f);
     }
   }
 
-  window.addEventListener("message", f)
-})
+  window.addEventListener("message", f);
+});
 
 /**
  * Prepare the element to cover quiz contents.
  */
-const examus_fader = () => {
+const createFader = () => {
   const x = document.createElement("div");
 
-  x.innerHTML = fader_html;
+  x.innerHTML = faderHTML;
 
   const style = {
     position: 'fixed',
@@ -101,16 +105,14 @@ const examus_fader = () => {
   return x;
 };
 
-window.addEventListener("DOMContentLoaded", function() {
-  let el = examus_fader()
+window.addEventListener("DOMContentLoaded", () => {
+  document.body.appendChild(createFader());
 
-  document.body.appendChild(el)
-
-  proved.then(() => el.remove())
+  proved.then(() => el.remove());
 
   /* Most of the time this action is meaningless,
    * at the same time it's always harmless. */
-  window.parent.postMessage('proctoringRequest', expected_origin);
+  window.parent.postMessage('proctoringRequest', expectedOrigin);
 });
 
 })();


### PR DESCRIPTION
We faced the problem with receiving a proving message, when moodle runs inside Electron-based Examus student applicaction.

The reason is cleared server session due to user relogin between opening the page with exam, and starting the quiz attempt.

Solution we implement here is to read `examus-client-origin` from url in the browser, but not on the server. And also store `examus-client-orgin` in the browser's `sessionStorage`, but not in the server session.